### PR TITLE
:bug: Differentiate test_exit_code with general exit_code

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -25,10 +25,10 @@ for test_dir in tests/*; do
     expect_error="${test_dir_path}/.expect-error"
 
     bin/run.sh "${test_dir_name}" "${test_dir_path}" "${test_dir_path}"
-    exit_code=$?
+    test_exit_code=$?
 
     if [[ -f "${expect_error}" ]]; then
-        if [[ $exit_code -eq 0 ]]; then
+        if [[ $test_exit_code -eq 0 ]]; then
             echo 'Expected non-zero exit code'
             exit_code=1
         fi


### PR DESCRIPTION
Fix returned `exit_code`: actually the script `exit_code` is the last `exit_code` so if the last test succeed the script will be marked as succeeded while it actually fails.