### PR TITLE
Dockerfile: bump Alpine from 3.10 to 3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.17
 
 # TODO: install packages required to run the representer
 RUN apk add --no-cache bash jq


### PR DESCRIPTION
See the list of [Alpine Linux releases][1].

[1]: https://alpinelinux.org/releases/

---

Can we bump this? Alpine 3.10 has been EOL for two years. Here are the minor version release notes:

- https://alpinelinux.org/posts/Alpine-3.11.0-released.html
- https://alpinelinux.org/posts/Alpine-3.12.0-released.html
- https://alpinelinux.org/posts/Alpine-3.13.0-released.html
- https://alpinelinux.org/posts/Alpine-3.14.0-released.html
- https://alpinelinux.org/posts/Alpine-3.15.0-released.html
- https://alpinelinux.org/posts/Alpine-3.16.0-released.html
- https://alpinelinux.org/posts/Alpine-3.17.0-released.html